### PR TITLE
Add `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "utf8-encode",
+  "version": "1.0.0",
+  "description": "Encode JavaScript strings in UTF8",
+  "main": "./index.js",
+  "repository": "ForbesLindesay/utf8-encode",
+  "author": "ForbesLindesay",
+  "license": "MIT",
+  "files": ["index.js"]
+}


### PR DESCRIPTION
`base64-encode` depends on this package but `npm` doesn't think this repo houses a package because there is no `package.json`.